### PR TITLE
Don't install python-setuptools as a package

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,7 +8,6 @@ pkg_dependencies = %w(
   postgresql-client
   pv
   python-dev
-  python-setuptools
 )
 
 # Handle older Ubuntu that had a different name


### PR DESCRIPTION
We install this in the python cookbook via pip instead.
